### PR TITLE
ci: update semantic check to only verify pr title

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# Always validate the PR title, and ignore the commits
+titleOnly: true


### PR DESCRIPTION
Since we usually squash I believe this is the way the check should happen, only verifying the pr title and not the commits.